### PR TITLE
Switch to Ubuntu 14.04 as a base

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Common Lisp Vagrantfile
 
 This is a minimal environment to set up a vagrant box for Common Lisp development.
 It includes the following features:
-* 32-bit Ubuntu Precise Pangolin based
+* 32-bit Ubuntu 14.04 Trusty Tahir based
 * SBCL
 * Emacs 24
 * Quicklisp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant::Config.run do |config|
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "ubuntu/trusty32"
   config.vm.forward_port 80, 8000
 
   config.vm.provision :puppet, :options => ["--debug", "--verbose"] do |puppet|


### PR DESCRIPTION
This patch updates the base operating system from Ubuntu 12.04 (Precise Pangolin) to Ubuntu 14.04 (Trusty Tahir).

I tested this with emacs / slime and it seems to work well for basic operations.

I've also tested this (on my master branch) with vim / slimv, where basic operations also worked well.

14.04 has sbcl 1.1.14 (vs. 1.0.55.0 in 12.04).

This is a cleaner patch than pull request #8.
