### PR TITLE
Update to Ubuntu 18.04 LTS Bionic Beaver 64 bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore backups
-*~
+*.log
 *.swp
-\#*\#
+*~
 .vagrant
+\#*\#

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@ Common Lisp Vagrantfile
 
 This is a minimal environment to set up a vagrant box for Common Lisp development.
 It includes the following features:
-* 32-bit Ubuntu 14.04 Trusty Tahir based
-* SBCL
-* clisp
-* Emacs 24
-* Quicklisp
-* Slime
-* vim 7.3
-* slimv
-* syntastic
-* tmux
-* Port 80 forwarded to localhost:8000
+* [Vagrant](https://vagrantup.com) support through [Virtualbox](https://www.virtualbox.org/)
+* 64-bit [Ubuntu 18.04 Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes) Linux distribution
+* [SBCL](http://www.sbcl.org/)
+* [clisp](https://clisp.sourceforge.io/)
+* [Emacs](https://www.gnu.org/software/emacs/) 24
+* [Quicklisp](https://www.quicklisp.org/)
+* [Slime](https://common-lisp.net/project/slime/)
+* [vim](https://www.vim.org/) 7.3
+* [slimv](https://kovisoft.bitbucket.io/tutorial.html)
+* [syntastic](https://github.com/scrooloose/syntastic)
+* [tmux](https://en.wikipedia.org/wiki/Tmux)
+* Port 80 forwarded to [localhost:8000](http://localhost:8000)
 
 To set up, clone the repository and run:
 
@@ -34,7 +35,7 @@ to support syntax / style checking with the vim [syntastic](https://github.com/s
 
 Getting started with emacs and slime
 ----
-[Emacs](https://www.gnu.org/software/emacs/) with [slime](https://common-lisp.net/project/slime/) is the dominant IDE used in the Common Lisp world [as of 2015](http://eudoxia.me/article/common-lisp-sotu-2015/).
+[Emacs](https://www.gnu.org/software/emacs/) with [slime](https://common-lisp.net/project/slime/) is the dominant IDE used in the Common Lisp world [as of 2015](https://borretti.me/article/common-lisp-sotu-2015).
 
 ![emacs slime session showing compilation output](emacs-session.png)
 
@@ -46,7 +47,7 @@ Start emacs:
 
     emacs hello.lisp
 
-Invoke `M-x slime` to start the REPL, and type lisp expressions: 
+Invoke `M-x slime` to start the REPL, and type lisp expressions:
 
     (format t "Hello, world!~%")
     (+ 1 2)
@@ -59,11 +60,11 @@ Add some lisp code, save wih `C-c C-s` and quit with `C-c C-x`.
 
 Getting started with vim and slimv
 ----
-If you would rather use a vi-family editor, don't despair. A port of slime to [vim](http://www.vim.org/) called [slimv](https://github.com/kovisoft/slimv) is available and configured in this image. 
+If you would rather use a vi-family editor, don't despair. A port of slime to [vim](http://www.vim.org/) called [slimv](https://github.com/kovisoft/slimv) is available and configured in this image.
 
 ![vim and slimv session showing syntastic output](vim-session.png)
 
-`vim` is configured with a slimv menu that you can get to using tab completion with the `:emenu slimv` command, or by hitting the `F4` key. 
+`vim` is configured with a slimv menu that you can get to using tab completion with the `:emenu slimv` command, or by hitting the `F4` key.
 
 The [slimv tutorial](http://kovisoft.bitbucket.org/tutorial.html) goes into detail about using `slimv` for lisp development.
 
@@ -73,7 +74,7 @@ Start vim:
 
     vim hello.lisp
 
-Invoke `:emenu Slimv.Repl.Connect-Server` to start the REPL. Switch to it with `control-w j`, enter insert mode with `i` and type lisp expressions: 
+Invoke `:emenu Slimv.Repl.Connect-Server` to start the REPL. Switch to it with `control-w j`, enter insert mode with `i` and type lisp expressions:
 
     (format t "Hello, world!~%")
     (+ 1 2)
@@ -89,7 +90,7 @@ The `vim` installation is set up using [Pathogen](https://github.com/tpope/vim-p
 
 Quicklisp package management
 ====
-This setup uses [quicklisp](https://www.quicklisp.org/beta/) for LISP package management. See the instructions in the previous link for instructions on loading packages. The `sbcl` installation in this package already has quicklisp loaded into its init files. 
+This setup uses [quicklisp](https://www.quicklisp.org/beta/) for LISP package management. See the instructions in the previous link for instructions on loading packages. The `sbcl` installation in this package already has quicklisp loaded into its init files.
 
 For example, invoke `sbcl` or start a `slime`/`slimv` REPL within `emacs` or `vim` and issue these statements in order to load the web development framework [clack](http://clacklisp.org/):
 
@@ -100,7 +101,7 @@ Further Reading
 
 * [Practical Common Lisp](http://www.gigamonkeys.com/book/) by Peter Seibel / [buy from amazon](http://www.amazon.com/Practical-Common-Lisp-Peter-Seibel/dp/1590592395)
 * [Land of Lisp](http://landoflisp.com/): Learn to Program in Lisp, One Game at a Time! by Conrad Barski / [buy from amazon](http://www.amazon.com/Land-Lisp-Learn-Program-Game/dp/1593272812)
-* [Common Lisp the Language](https://www.cs.cmu.edu/Groups/AI/html/cltl/cltl2.html) by Guy Steele / [buy from amazon](http://www.amazon.com/Common-LISP-Language-Second-Edition/dp/1555580416) 
+* [Common Lisp the Language](https://www.cs.cmu.edu/Groups/AI/html/cltl/cltl2.html) by Guy Steele / [buy from amazon](http://www.amazon.com/Common-LISP-Language-Second-Edition/dp/1555580416)
 * [Setting up a Vim-based Common Lisp development environment on Ubuntu](http://journal.okal.me/post/75919443198/setting-up-a-vim-based-common-lisp-development)
 * [Quickstart: Getting Started with Clojure via Vim, Lein, Slimv (Windows + Linux)](http://adambard.com/blog/quickstart-clojure-on-vim-lein-slimv-windows/)
 * [Using Vim for Lisp developmenbt](http://stackoverflow.com/questions/94792/using-vim-for-lisp-development)
@@ -112,4 +113,4 @@ If you are stuck in a LISP REPL and need to exit it, you can type:
     (quit)
 
 and the REPL will exit.
-    
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,45 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# Vagrantfile for vagrant-common-lisp
+# 
+# Invoke this way to print extra debugging info:
+#
+#     DEBUG=true vagrant up
+#
+# or:
+#
+#     DEBUG=true vagrant provision
+#
+# Invoke with PORT_FORWARD to switch the port that the guest port 80
+# is forwarded to:
+#
+#     PORT_FORWARD=8888 vagrant up
+
+case ENV["DEBUG"]
+when "true"
+    puppet_install = "apt-get update && apt-get install -y puppet"
+    puppet_options = ["--debug", "--verbose"]
+else
+    puppet_install = "apt-get -qq update && apt-get -qq install puppet"
+    puppet_options = []
+end
+
+case ENV["PORT_FORWARD"]
+when /^([1-9][0-9]*)/
+    port_forward = ENV["PORT_FORWARD"]
+else
+    port_forward=8000
+end
+
 
 Vagrant::Config.run do |config|
-  config.vm.box = "ubuntu/trusty32"
-  config.vm.forward_port 80, 8000
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.forward_port 80, port_forward
 
-  config.vm.provision :puppet, :options => ["--debug", "--verbose"] do |puppet|
+  config.vm.provision :shell, inline: puppet_install
+
+  config.vm.provision :puppet, :options => puppet_options do |puppet|
     puppet.manifests_path = "private/puppet/manifests"
     puppet.module_path = "private/puppet/modules"
     puppet.manifest_file  = "base.pp"

--- a/private/puppet/manifests/base.pp
+++ b/private/puppet/manifests/base.pp
@@ -2,22 +2,8 @@ exec { 'initial update':
   command => '/usr/bin/apt-get update',
 }
 
-package { ['curl', 'python-software-properties']:
-  ensure => present,
-  require => Exec['initial update'],
-}
-
-exec { 'add emacs repository':
-  command => '/usr/bin/add-apt-repository ppa:cassou/emacs -y',
-  require => Package['python-software-properties'],
-}
-
-exec { 'second update':
-  command => '/usr/bin/apt-get update',
-  require => Exec['add emacs repository'],
-}
-
-package { ['emacs24', 'emacs24-el', 'emacs24-common-non-dfsg',
+package { ['emacs25', 'emacs25-el', 'emacs25-common-non-dfsg',
+           'curl',
            'git-core',
            'sbcl', 'sbcl-doc', 'sbcl-source',
            'clisp', 'clisp-doc','clisp-dev', 'gdb',
@@ -25,7 +11,7 @@ package { ['emacs24', 'emacs24-el', 'emacs24-common-non-dfsg',
            'vim-nox',
            ]:
   ensure => present,
-  require => Exec['second update'],
+  require => Exec['initial update'],
 }
 
 exec { 'download quicklisp':
@@ -175,7 +161,7 @@ exec { 'download syntastic':
 exec { 'install syntastic':
   user => 'vagrant',
   cwd => '/home/vagrant/.vim/bundle/syntastic',
-  command => '/usr/bin/git checkout 3.7.0',
+  command => '/usr/bin/git checkout 3.10.0',
   require => [ File['dot-vim'],
                File['dot-vimrc'],
                Exec['download syntastic'],
@@ -199,7 +185,7 @@ exec { 'download slimv':
 exec { 'install slimv':
   user => 'vagrant',
   cwd => '/home/vagrant/.vim/bundle/slimv',
-  command => '/usr/bin/git checkout 0.9.12',
+  command => '/usr/bin/git checkout c832d79c2fdeb094cae109e45c1c41d3d520af2a',
   require => [ File['dot-vim'],
                File['dot-vimrc'],
                Exec['download slimv'],


### PR DESCRIPTION
This switches to the latest supported Ubuntu LTS release, 18.04 (Bionic Beaver). The previous version, 14.04, is out of support now.

 * Simplify emacs distribution configuration - no more external ppa repo required
 * Use slimv 0.10.13 (use raw commit hash since upstream repo lacks tag)
 * Ignore log files too, sort .gitignore
 * Fix some links

I tested starting both emacs / slime and vim / slimv with this patch set, and things seemed to be working OK.